### PR TITLE
Make it work with current Node.js.

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,9 +1,9 @@
 var cuid = require('cuid')
-var level = require('level')
+const { Level } = require('level')
 var charwise = require('charwise')
 var Transactor = require('level-fact-base')
 
-var db = level('db', {
+const db = new Level('db', {
   keyEncoding: charwise, // or any codec for sorted arrays of flat json values
   valueEncoding: 'json'
 })

--- a/example/index.js
+++ b/example/index.js
@@ -1,4 +1,4 @@
-var cuid = require('cuid')
+const { createId: cuid } = require('@paralleldrive/cuid2')
 const { Level } = require('level')
 var charwise = require('charwise')
 var Transactor = require('level-fact-base')

--- a/example/package.json
+++ b/example/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "charwise": "^3.0.1",
     "cuid": "^2.1.4",
-    "level": "^4.0.0",
+    "level": "8.0.0",
     "level-fact-base": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "test": "standard && ava"
   },
   "dependencies": {
+    "@paralleldrive/cuid2": "2.2.0",
     "async": "^2.6.0",
-    "cuid": "^2.1.1",
     "fastq": "^1.5.0",
     "level-read-stream": "1.1.0",
     "memory-level": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -31,15 +31,13 @@
   "dependencies": {
     "async": "^2.6.0",
     "cuid": "^2.1.1",
-    "fastq": "^1.5.0"
+    "fastq": "^1.5.0",
+    "level-read-stream": "1.1.0",
+    "memory-level": "1.0.0"
   },
   "devDependencies": {
     "ava": "^1.1.0",
     "charwise": "^3.0.1",
-    "encoding-down": "^6.0.1",
-    "leveldown": "^4.0.1",
-    "levelup": "^4.0.0",
-    "memdown": "^3.0.0",
     "standard": "^12.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "memory-level": "1.0.0"
   },
   "devDependencies": {
-    "ava": "^1.1.0",
+    "ava": "5.2.0",
     "charwise": "^3.0.1",
     "standard": "^12.0.1"
   }

--- a/src/dbRange.js
+++ b/src/dbRange.js
@@ -1,3 +1,5 @@
+const { EntryStream } = require('level-read-stream')
+
 var promisify = require('./promisify')
 
 module.exports = function dbRange (db, opts, onData, callbackOrig) {
@@ -17,7 +19,7 @@ module.exports = function dbRange (db, opts, onData, callbackOrig) {
     opts.lte = opts.prefix.concat([void 0])
   }
 
-  var stream = db.createReadStream(opts)
+  const stream = new EntryStream(db, opts)
   stream.on('error', callback)
   stream.on('end', callback)
   function stopRange () {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 var eachSeries = require('async/eachSeries')
-var cuid = require('cuid')
+const { createId: cuid } = require('@paralleldrive/cuid2')
 var dbRange = require('./dbRange')
 var fastq = require('fastq')
 var promisify = require('./promisify')

--- a/test.js
+++ b/test.js
@@ -1,16 +1,11 @@
 var charwise = require('charwise')
 var dbRange = require('./src/dbRange')
-var encode = require('encoding-down')
-var levelup = require('levelup')
-var memdown = require('memdown')
+const { MemoryLevel } = require('memory-level')
 var test = require('ava')
 var Transactor = require('./')
 
 function mkDB () {
-  return levelup(encode(memdown(), {
-    keyEncoding: charwise,
-    valueEncoding: 'json'
-  }))
+  return new MemoryLevel({ keyEncoding: charwise, valueEncoding: 'json' })
 }
 
 var mkNextId = function () {


### PR DESCRIPTION
level-fact-base doesn't work with the current Node.js version (20).  This pull request modernizes the package by upgrading various dependencies, including Level and Cuid, and follows the industry in moving from the Standard coding style to Prettier.